### PR TITLE
fix: move 'node-rsa' from dev dependencies to prod

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5143,7 +5143,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/node-rsa/-/node-rsa-1.0.5.tgz",
       "integrity": "sha512-9o51yfV167CtQANnuAf+5owNs7aIMsAKVLhNaKuRxihsUUnfoBMN5OTVOK/2mHSOWaWq9zZBiRM3bHORbTZqrg==",
-      "dev": true,
       "requires": {
         "asn1": "^0.2.4"
       },
@@ -5152,7 +5151,6 @@
           "version": "0.2.4",
           "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
           "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-          "dev": true,
           "requires": {
             "safer-buffer": "~2.1.0"
           }
@@ -8814,8 +8812,7 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "semver": {
       "version": "5.5.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "got": "^8.3.1",
     "is": "^3.2.1",
     "md5": "^2.2.1",
+    "node-rsa": "^1.0.5",
     "randomatic": "^3.0.0",
     "sort-keys-recursive": "^2.0.1"
   },
@@ -18,7 +19,6 @@
   "devDependencies": {
     "ava": "^0.25.0",
     "coveralls": "^3.0.1",
-    "node-rsa": "^1.0.5",
     "nyc": "^11.8.0",
     "xo": "^0.21.1"
   },


### PR DESCRIPTION
Recent API changes accidentally added 'node-rsa' to dev dependencies instead of prod ones. Correct that.